### PR TITLE
App 2626 fixed positioning option

### DIFF
--- a/lib/rendered-multi-select/helpers.rb
+++ b/lib/rendered-multi-select/helpers.rb
@@ -10,7 +10,8 @@ module RenderedMultiSelect
       tag_options = html_options.merge(
         :class => "rendered-multi-select #{html_options[:class]} #{'editable' unless readonly}",
         "data-readonly" => readonly,
-        "data-multiple" => multiple)
+        "data-multiple" => multiple,
+        "data-fixed-menu" => options[:fixed_menu])
       
       if !!options[:readonly]
         close_box = ""

--- a/lib/rendered-multi-select/version.rb
+++ b/lib/rendered-multi-select/version.rb
@@ -1,3 +1,3 @@
 module RenderedMultiSelect
-  VERSION = "1.0.41"
+  VERSION = "1.0.42"
 end

--- a/vendor/assets/javascripts/control.js.coffee
+++ b/vendor/assets/javascripts/control.js.coffee
@@ -19,7 +19,7 @@ class RenderedMultiSelect
       @updateQuery(event)
     @element.on "blur", ".editable-input", (event) =>
       # Create any partially edited item if it allows new options
-      if (index = @resultList.find("li").map(() -> $(this).text().toLowerCase()).get().indexOf(@input.text().toLowerCase())) >= 0
+      if @input.text() && (index = @resultList.find("li").map(() -> $(this).text().toLowerCase()).get().indexOf(@input.text().toLowerCase())) >= 0
         @addItem(@resultList.find("li").eq(index))
       else if @options.allowNew
         @createNewItem(@input.text())

--- a/vendor/assets/javascripts/control.js.coffee
+++ b/vendor/assets/javascripts/control.js.coffee
@@ -79,19 +79,22 @@ class RenderedMultiSelect
     return @resultMenu.show() unless @element.attr("data-fixed-menu") == "true"
 
     winHeight = @win.height()
-    coors     = @inputContainer.offset()
+    inputTop  = @inputContainer.offset().top
+    elemLeft  = @element.offset().left
     scrollTop = @body.scrollTop()
     rules     = 
       display: 'block'
-      left:    coors.left - @body.scrollLeft()
+      left:    elemLeft - @body.scrollLeft()
+      width:   @element.width()
 
-    if winHeight / 2 < coors.top - scrollTop
-      rules.bottom = winHeight - coors.top + scrollTop - @inputContainer.height()
+    if winHeight / 2 < inputTop - scrollTop
+      rules.bottom = winHeight - inputTop + scrollTop
     else
-      rules.top = coors.top - scrollTop
+      rules.top = inputTop - scrollTop + @inputContainer.height()
 
     @resultMenu.css(rules)
     @body.css(overflow: 'hidden')
+    return
 
   hideResultMenu: (fade=false) ->
     @body.css(overflow: 'auto') if @element.attr("data-fixed-menu") == "true"

--- a/vendor/assets/javascripts/control.js.coffee
+++ b/vendor/assets/javascripts/control.js.coffee
@@ -1,6 +1,7 @@
 class RenderedMultiSelect
   constructor: (@element, @options) ->
     return if @element.data("readonly") == "true"
+    @body = $('body')
     @inputContainer = @element.find(".rendered-multi-select-input")
     @input = @inputContainer.find(".editable-input")
     @createResultMenu()
@@ -33,14 +34,14 @@ class RenderedMultiSelect
       @element.addClass("rendered-multi-select-active")
       @lastName = null
       @updateQuery()
-    @element.on "click", ".rendered-multi-select-menu li", (event) =>
+    @resultMenu.on "click", "li", (event) =>
       @addItem($(event.target))
       event.stopPropagation()
-    @element.on "focus", ".rendered-multi-select-menu", (event) =>
+    @resultMenu.on "focus", (event) =>
       unless @input.is(":focus")
         clearTimeout @blurTimeout if @blurTimeout
         @input[0].focus() if @input[0]
-    @element.on "mousedown", ".rendered-multi-select-menu", (event) =>
+    @resultMenu.on "mousedown", (event) =>
       false
     @element.on "click", ".rendered-multi-select-element b", (event) =>
       @deleteItem($(event.target).parent(".rendered-multi-select-element"))
@@ -64,8 +65,23 @@ class RenderedMultiSelect
   
   createResultMenu: ->
     @resultMenu = $("<div class='rendered-multi-select-menu'><ul class='rendered-multi-select-results'></ul></div")
-    @resultMenu.insertAfter(@input)
+
+    if @element.attr("data-fixed-menu") == "true"
+      @resultMenu.addClass('fixed')
+      @body.append(@resultMenu)
+    else
+      @resultMenu.insertAfter(@input)
+
     @resultList = @resultMenu.find("ul")
+
+  showResultMenu: ->
+    return @resultMenu.show() unless @element.attr("data-fixed-menu") == "true"
+
+    coors = @inputContainer.offset()
+    @resultMenu.css
+      display:  'block',
+      top:      coors.top - @body.scrollTop(),
+      left:     coors.left - @body.scrollLeft(),
     
   inputKeyDown: (event) ->
     switch event.keyCode
@@ -147,7 +163,7 @@ class RenderedMultiSelect
 
     if resultAdded
       # Only if we have focus.
-      @resultMenu.show() if $(@input).is(":focus")
+      @showResultMenu() if $(@input).is(":focus")
     else
       @resultMenu.hide()
     

--- a/vendor/assets/stylesheets/rendered-multi-select.css.less
+++ b/vendor/assets/stylesheets/rendered-multi-select.css.less
@@ -136,7 +136,6 @@ ul.rendered-multi-select {
   &.fixed {
     z-index: 1000;
     position: fixed;
-    max-width: 250px;
   }
   
   ul {

--- a/vendor/assets/stylesheets/rendered-multi-select.css.less
+++ b/vendor/assets/stylesheets/rendered-multi-select.css.less
@@ -97,55 +97,6 @@ ul.rendered-multi-select {
       user-select: text;
       -webkit-user-select: text;
     }
-    .rendered-multi-select-menu {
-      position: absolute;
-      right: -1px;
-      left: -1px;
-      margin-top: 3px;
-      border: 1px solid #ccc;
-      background-color: white;
-      overflow: auto;
-      min-width: 150px;
-      min-height: 10px;
-      max-height: 250px;
-      display: none;
-      z-index: 100;
-      
-      ul {
-        list-style: none;
-        margin: 0;
-        padding: 0;
-        
-        li {
-          cursor: default;
-          color: #444;
-          font-size: 13px;
-          padding: 3px;
-          padding-left: 6px;
-          
-          &:hover {
-            background-color: #eee; 
-          }
-          &.selected {
-            background-color: #eee; 
-          }
-
-          &.header-row {
-            color: #777;
-            font-size: 13px;
-
-            &:hover, &.selected {
-              background-color: #fff !important;
-              color: #777 !important;
-            }
-          }
-
-          &.has-parent {
-            padding-left: 20px;
-          }
-        }
-      }
-    }
   }
   
   &.rendered-multi-select-light-tags {
@@ -163,6 +114,61 @@ ul.rendered-multi-select {
         &:hover {
           color: rgba(0,0,0,0.9);
         }
+      }
+    }
+  }
+}
+
+.rendered-multi-select-menu {
+  position: absolute;
+  right: -1px;
+  left: -1px;
+  margin-top: 3px;
+  border: 1px solid #ccc;
+  background-color: white;
+  overflow: auto;
+  min-width: 150px;
+  min-height: 10px;
+  max-height: 250px;
+  display: none;
+  z-index: 100;
+
+  &.fixed {
+    position: fixed;
+    max-width: 250px;
+  }
+  
+  ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    
+    li {
+      cursor: default;
+      color: #444;
+      font-size: 13px;
+      padding: 3px;
+      padding-left: 6px;
+      
+      &:hover {
+        background-color: #eee; 
+      }
+      &.selected {
+        background-color: #eee; 
+      }
+
+      &.header-row {
+        color: #777;
+        font-size: 13px;
+
+        &:hover, &.selected {
+          background-color: #fff !important;
+          color: #777 !important;
+        }
+      }
+
+      &.has-parent {
+        padding-left: 20px;
       }
     }
   }

--- a/vendor/assets/stylesheets/rendered-multi-select.css.less
+++ b/vendor/assets/stylesheets/rendered-multi-select.css.less
@@ -134,6 +134,7 @@ ul.rendered-multi-select {
   z-index: 100;
 
   &.fixed {
+    z-index: 1000;
     position: fixed;
     max-width: 250px;
   }


### PR DESCRIPTION
if `data-fixed-menu="true"` is set on the `@element`, then the popup multi select menu will be rendered using fixed positioning where the menu itself is appended to the `body` tag.

- adds wrapper methods for hiding & showing the menu
- locks scrolling when the menu is active similar to `selectro`
- positions the menu heading downwards when the input is in the top half of the viewable screen, and upwards if it's in the bottom, similar to `selectro`
- reorients some event delegates to be directly on the menu itself as opposed to the element container (since the menu is no longer guaranteed to exist w/n the element container)
- moves some CSS rules to reflect that the menu can exist outside of the element's CSS scope
- all the above only occurs if the top most mentioned data attribute is set